### PR TITLE
Add ability to select a country to compare to

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -74,11 +74,14 @@ function johnsHopkinsDataMapper(results, countryFilter, mode) {
     };
 }
 
-function countryEquals(country) {
-    return function(record) {
-        return !_.includes(NON_PROVINCES, record['Province/State']) &&
-        record['Country/Region'].toLowerCase() === country.toLowerCase();
-    }
+function countryEquals(countries) {
+  return function(record) {
+      countries = countries.map(country => country.toLowerCase());
+    return (
+      !_.includes(NON_PROVINCES, record["Province/State"]) &&
+      countries.indexOf(record["Country/Region"].toLowerCase()) >= 0
+    );
+  };
 }
 
 
@@ -109,22 +112,17 @@ function readCsv(path, cb) {
         .on('end', () => cb(results));
 }
 
-app.get('/api/data/:country', (req, res) => {
-    let results = []
+app.get('/api/data/:countries', (req, res) => {
+    const countries = req.params.countries.split(",");
+
     readCsv(`${dataDir}/confirmed.csv`, results => {
         res.send(
             johnsHopkinsDataMapper(
                 results,
-                countryEquals(req.params.country),
+                countryEquals(countries),
                 req.query.mode
             )
         );
-        // .on('end', () => {
-        //     const countryData = results.filter(record => {
-        //         return countries.indexOf(record["Country/Region"].toLowerCase()) >= 0;
-        //     });
-
-        //     res.send(countryData);
     });
 });
 

--- a/src/js/components/Chart.jsx
+++ b/src/js/components/Chart.jsx
@@ -101,7 +101,7 @@ export default class Chart extends React.Component {
                 x
             });
 
-            this.renderChart(this.state.x, this.state.data);
+            this.renderChart();
         });
     }
 
@@ -116,7 +116,7 @@ export default class Chart extends React.Component {
         return data.map(province => {
             const dropped = _.drop(_.values(province), 4);
 
-            const concatted = _.concat(
+            return _.concat(
                 [
                     province["Province/State"].length > 0
                         ? province["Province/State"]
@@ -124,20 +124,17 @@ export default class Chart extends React.Component {
                 ],
                 this.validateValues(dropped)
             );
-
-            return concatted;
         });
     }
 
     getXLabels(data) {
         const keys = _.keys(data);
         const filteredKeys = keys.filter(x => !_.includes(excludedFields, x));
-        const x = _.concat(
+
+        return _.concat(
             ["x"],
             filteredKeys.map(x => moment(x, "MM/DD/YY").toDate())
         );
-
-        return x;
     }
 
     onCompareChange(event) {

--- a/src/js/components/Chart.jsx
+++ b/src/js/components/Chart.jsx
@@ -1,164 +1,133 @@
-import React from 'react';
-import ChartToggles from './ChartToggles'
-import c3 from 'c3'
-import superagent from 'superagent'
-import _ from 'lodash'
-import moment from 'moment'
+import React from "react";
+import ChartToggles from "./ChartToggles";
+import c3 from "c3";
+import superagent from "superagent";
+import _ from "lodash";
+import moment from "moment";
 
 const excludedFields = ["Lat", "Long", "Province/State", "Country/Region"];
 
 export default class Chart extends React.Component {
-    constructor(props) {
-        super(props);
+  constructor(props) {
+    super(props);
 
-        this.state = {
-            data: {},
-            x: {},
-            compareToCountry: "",
-            countries: []
-        };
+    this.state = {
+      timeseries: {},
+      compareToCountry: "",
+      countries: [],
+      chartMode: "total"
+    };
 
-        this.getData = this.getData.bind(this);
-        this.getCountryList = this.getCountryList.bind(this);
-        this.onCompareChange = this.onCompareChange.bind(this);
-    }
+    this.getData = this.getData.bind(this);
+    this.getCountryList = this.getCountryList.bind(this);
+    this.onCompareChange = this.onCompareChange.bind(this);
+    this.onChartModeChange = this.onChartModeChange.bind(this);
+  }
 
-    //TODO: parameterize some of this stuff to make <Chart> reusable-ish
-    renderChart(timeseries) {
-        let dates = timeseries.x.map(date => new Date(date));
-        let data = _.concat([_.concat('x', dates)], timeseries.data)
+  //TODO: parameterize some of this stuff to make <Chart> reusable-ish
+  renderChart() {
+    const dates = this.state.timeseries.x.map(date => new Date(date));
+    const data = _.concat([_.concat("x", dates)], this.state.timeseries.data);
 
-        c3.generate({
-            bindto: ".chart",
-            data: {
-                x: 'x',
-                columns: data
+    c3.generate({
+      bindto: ".chart",
+      data: {
+        x: "x",
+        columns: data
+      },
+      axis: {
+        x: {
+          label: "Date",
+          type: "timeseries",
+          tick: {
+            format: function(x) {
+              return moment(x).format("MMM DD YYYY");
             },
-            axis: {
-                x: {
-                    label: 'Date',
-                    type: 'timeseries',
-                    tick: {
-                        format: function(x) {
-                            return moment(x).format('MMM DD YYYY')
-                        },
-                        culling: {
-                            max: 6
-                        },
-                        rotate: 45
-
-                    }
-                },
-                y: {
-                    label: "Number of Confirmed Cases"
-                }
+            culling: {
+              max: 6
             },
-            legend: {
-                position: 'right'
-            }
-        });
-    }
+            rotate: 45
+          }
+        },
+        y: {
+          label: "Number of Confirmed Cases"
+        }
+      },
+      legend: {
+        position: "right"
+      }
+    });
+  }
 
-    validateValues(values) {
-        return values.map((value, index, array) => {
-            return index > 1 && array[index - 1] > value
-                ? array[index - 1]
-                : value;
-        });
-    }
+  validateValues(values) {
+    return values.map((value, index, array) => {
+      return index > 1 && array[index - 1] > value ? array[index - 1] : value;
+    });
+  }
 
-    componentDidMount() {
-        superagent.get('/api/data/canada').then((res) => {
-            this.renderChart(res.body)
-        });
-    }
+  componentDidMount() {
+    this.getData();
+    this.getCountryList();
+  }
 
-    onChartModeChange(e) {
-        superagent.get(`/api/data/canada?mode=${e.target.value}`).then((res) => {
-            this.renderChart(res.body)
-        })
-        this.getData();
-        this.getCountryList();
-    }
+  onChartModeChange(e) {
+    this.setState({ chartMode: e.target.value }, this.getData);
+  }
 
-    getData() {
-        let queryString = "/api/data/canada";
+  getData() {
+    const { compareToCountry, chartMode } = this.state;
 
-        const { compareToCountry } = this.state;
+    let queryString = "/api/data/canada";
 
-        queryString =
-            compareToCountry && compareToCountry.length > 0
-                ? `${queryString},${compareToCountry.trim().toLowerCase()}`
-                : queryString;
+    // Check for compare-to country
+    queryString =
+      compareToCountry && compareToCountry.length > 0
+        ? `${queryString},${compareToCountry.trim().toLowerCase()}`
+        : queryString;
 
-        superagent.get(queryString).then(res => {
-            const data = this.cleanUpData(res.body);
+    // Set the data mode (i.e., total vs. percapita)
+    queryString = `${queryString}?mode=${chartMode}`;
 
-            const x = this.getXLabels(res.body[0]);
+    superagent.get(queryString).then(res => {
+      this.setState({
+        timeseries: res.body
+      });
 
-            this.setState({
-                data,
-                x
-            });
+      this.renderChart(); // TODO: maybe move this out? separation of concerns, etc.
+    });
+  }
 
-            this.renderChart();
-        });
-    }
+  getCountryList() {
+    superagent.get("api/data/countries").then(res => {
+      const countries = res.body.sort();
+      this.setState({ countries: ["", ...countries] });
+    });
+  }
 
-    getCountryList() {
-        superagent.get("api/data/countries").then(res => {
-            const countries = res.body.sort();
-            this.setState({ countries: ["", ...countries] });
-        });
-    }
+  onCompareChange(event) {
+    this.setState({ compareToCountry: event.target.value }, this.getData);
+  }
 
-    cleanUpData(data) {
-        return data.map(province => {
-            const dropped = _.drop(_.values(province), 4);
-
-            return _.concat(
-                [
-                    province["Province/State"].length > 0
-                        ? province["Province/State"]
-                        : province["Country/Region"]
-                ],
-                this.validateValues(dropped)
-            );
-        });
-    }
-
-    getXLabels(data) {
-        const keys = _.keys(data);
-        const filteredKeys = keys.filter(x => !_.includes(excludedFields, x));
-
-        return _.concat(
-            ["x"],
-            filteredKeys.map(x => moment(x, "MM/DD/YY").toDate())
-        );
-    }
-
-    onCompareChange(event) {
-        this.setState({ compareToCountry: event.target.value }, this.getData);
-    }
-
-    render() {
-        return (
-            <div className="wrapper">
-                <div className="d-flex justify-content-around">
-                    <ChartToggles onChartModeChange={this.onChartModeChange.bind(this)}></ChartToggles>
-                </div>
-                <div className="chart"></div>
-                <p>Compare to another country:</p>
-                <select
-                    name="compareToCountry"
-                    id="compareToCountry"
-                    onChange={this.onCompareChange}
-                >
-                    {this.state.countries.map(country => (
-                        <option key={country}>{country}</option>
-                    ))}
-                </select>
-            </div>
-        );
-    }
+  render() {
+    return (
+      <div className="wrapper">
+        <div className="d-flex justify-content-around">
+          <ChartToggles
+            onChartModeChange={this.onChartModeChange}
+          ></ChartToggles>
+        </div>
+        <div className="chart"></div>
+        <p>Compare to another country:</p>
+        <select
+          name="compareToCountry"
+          id="compareToCountry"
+          onChange={this.onCompareChange}
+        >
+          {this.state.countries.map(country => (
+            <option key={country}>{country}</option>
+          ))}
+        </select>
+      </div>
+    );
+  }
 }

--- a/src/js/components/Chart.jsx
+++ b/src/js/components/Chart.jsx
@@ -5,14 +5,31 @@ import superagent from 'superagent'
 import _ from 'lodash'
 import moment from 'moment'
 
-export default class Chart extends React.Component {  
+const excludedFields = ["Lat", "Long", "Province/State", "Country/Region"];
+
+export default class Chart extends React.Component {
+    constructor(props) {
+        super(props);
+
+        this.state = {
+            data: {},
+            x: {},
+            compareToCountry: "",
+            countries: []
+        };
+
+        this.getData = this.getData.bind(this);
+        this.getCountryList = this.getCountryList.bind(this);
+        this.onCompareChange = this.onCompareChange.bind(this);
+    }
+
     //TODO: parameterize some of this stuff to make <Chart> reusable-ish
     renderChart(timeseries) {
         let dates = timeseries.x.map(date => new Date(date));
         let data = _.concat([_.concat('x', dates)], timeseries.data)
 
         c3.generate({
-            bindto: '.chart',
+            bindto: ".chart",
             data: {
                 x: 'x',
                 columns: data
@@ -29,39 +46,122 @@ export default class Chart extends React.Component {
                             max: 6
                         },
                         rotate: 45
-                        
+
                     }
                 },
                 y: {
-                    label: 'Number of Confirmed Cases'
+                    label: "Number of Confirmed Cases"
                 }
             },
             legend: {
                 position: 'right'
             }
-        })
+        });
+    }
+
+    validateValues(values) {
+        return values.map((value, index, array) => {
+            return index > 1 && array[index - 1] > value
+                ? array[index - 1]
+                : value;
+        });
     }
 
     componentDidMount() {
         superagent.get('/api/data/canada').then((res) => {
             this.renderChart(res.body)
-        })
+        });
     }
 
     onChartModeChange(e) {
         superagent.get(`/api/data/canada?mode=${e.target.value}`).then((res) => {
             this.renderChart(res.body)
         })
+        this.getData();
+        this.getCountryList();
+    }
+
+    getData() {
+        let queryString = "/api/data/canada";
+
+        const { compareToCountry } = this.state;
+
+        queryString =
+            compareToCountry && compareToCountry.length > 0
+                ? `${queryString},${compareToCountry.trim().toLowerCase()}`
+                : queryString;
+
+        superagent.get(queryString).then(res => {
+            const data = this.cleanUpData(res.body);
+
+            const x = this.getXLabels(res.body[0]);
+
+            this.setState({
+                data,
+                x
+            });
+
+            this.renderChart(this.state.x, this.state.data);
+        });
+    }
+
+    getCountryList() {
+        superagent.get("api/data/countries").then(res => {
+            const countries = res.body.sort();
+            this.setState({ countries: ["", ...countries] });
+        });
+    }
+
+    cleanUpData(data) {
+        return data.map(province => {
+            const dropped = _.drop(_.values(province), 4);
+
+            const concatted = _.concat(
+                [
+                    province["Province/State"].length > 0
+                        ? province["Province/State"]
+                        : province["Country/Region"]
+                ],
+                this.validateValues(dropped)
+            );
+
+            return concatted;
+        });
+    }
+
+    getXLabels(data) {
+        const keys = _.keys(data);
+        const filteredKeys = keys.filter(x => !_.includes(excludedFields, x));
+        const x = _.concat(
+            ["x"],
+            filteredKeys.map(x => moment(x, "MM/DD/YY").toDate())
+        );
+
+        return x;
+    }
+
+    onCompareChange(event) {
+        this.setState({ compareToCountry: event.target.value }, this.getData);
     }
 
     render() {
         return (
-            <div>  
+            <div className="wrapper">
                 <div className="d-flex justify-content-around">
                     <ChartToggles onChartModeChange={this.onChartModeChange.bind(this)}></ChartToggles>
-                </div>                  
+                </div>
                 <div className="chart"></div>
+                <p>Compare to another country:</p>
+                <select
+                    name="compareToCountry"
+                    id="compareToCountry"
+                    onChange={this.onCompareChange}
+                >
+                    {this.state.countries.map(country => (
+                        <option key={country}>{country}</option>
+                    ))}
+                </select>
             </div>
-        )
+        );
     }
 }

--- a/src/js/components/Chart.jsx
+++ b/src/js/components/Chart.jsx
@@ -93,7 +93,7 @@ export default class Chart extends React.Component {
         timeseries: res.body
       });
 
-      this.renderChart(); // TODO: maybe move this out? separation of concerns, etc.
+      this.renderChart();
     });
   }
 
@@ -117,8 +117,9 @@ export default class Chart extends React.Component {
           ></ChartToggles>
         </div>
         <div className="chart"></div>
-        <p>Compare to another country:</p>
-        <select
+        {/* Hide compare-to country until State/Province totalling works */}
+        {/* <p>Compare to another country:</p> */}
+        {/* <select
           name="compareToCountry"
           id="compareToCountry"
           onChange={this.onCompareChange}
@@ -126,7 +127,7 @@ export default class Chart extends React.Component {
           {this.state.countries.map(country => (
             <option key={country}>{country}</option>
           ))}
-        </select>
+        </select> */}
       </div>
     );
   }


### PR DESCRIPTION
## Changes
Added the ability to select a country to compare the provinces to. 

There's an issue I'd like to fix, but I'm opening a draft PR so you can get an early look.

## Ongoing Issue
Right now, if you select a country with a large number of provinces/states, the chart gets mangled because it gets way too many labels. E.g., if you select `US` from the dropdown, the tab lags quite a bit and the chart is unreadable because there are so many labels. I plan on fixing this by summing the values for all States and creating a single plotted line for the entire country. 

## Formatting
Sorry about so many whitespace/formatting changes. I forgot to turn off the "Format on Save" option in my editor :disappointed: I can revert those changes before merging if you'd like.

## Future Tasks
Future things I plan on working on if/when I have time:
- Creating a field to set an "offset" so that the entries in the "compare-to" country can be offset from the Canadian dates
- Creating a way to select a date range 
- Order the labels so that the "compare-to" country comes first, and provinces follow

## Screenshots
It ain't pretty, but it works

![Screenshot_2020-03-23 Screenshot](https://user-images.githubusercontent.com/10404392/77380391-f133d400-6d48-11ea-959c-c5742ae38ff9.png)
![Screenshot_2020-03-23 Screenshot(1)](https://user-images.githubusercontent.com/10404392/77380394-f2650100-6d48-11ea-8358-ea1d7918e6bb.png)
