### PR TITLE
Enable "Compare to Other Country" 🎉

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -161,8 +161,14 @@ app.get("/api/data/countries", (req, res) => {
         });
 });
 
-app.get("/api/data/:countries", (req, res) => {
-    const countries = req.params.countries.split(",");
+app.get("/api/data/:country", (req, res) => {
+    const baseCountry = req.params.country;
+    const compareToCountry = req.query.compareTo;
+    const countries = [baseCountry];
+
+    if (compareToCountry != null) {
+        countries.push(compareToCountry);
+    }
 
     // Disable per capita when comparing countries until we can get population data ready for all countries
     // TODO: when per capita works worldwide, modify following line

--- a/src/js/components/Chart.jsx
+++ b/src/js/components/Chart.jsx
@@ -114,12 +114,12 @@ export default class Chart extends React.Component {
         <div className="d-flex justify-content-around">
           <ChartToggles
             onChartModeChange={this.onChartModeChange}
+            disabled={this.state.compareToCountry !== ""}
           ></ChartToggles>
         </div>
         <div className="chart"></div>
-        {/* Hide compare-to country until State/Province totalling works */}
-        {/* <p>Compare to another country:</p> */}
-        {/* <select
+        <p>Compare to another country:</p>
+        <select
           name="compareToCountry"
           id="compareToCountry"
           onChange={this.onCompareChange}
@@ -127,7 +127,7 @@ export default class Chart extends React.Component {
           {this.state.countries.map(country => (
             <option key={country}>{country}</option>
           ))}
-        </select> */}
+        </select>
       </div>
     );
   }

--- a/src/js/components/Chart.jsx
+++ b/src/js/components/Chart.jsx
@@ -78,23 +78,24 @@ export default class Chart extends React.Component {
     const { compareToCountry, chartMode } = this.state;
 
     let queryString = "/api/data/canada";
+    let queryParams = {
+        mode: chartMode
+    };
 
-    // Check for compare-to country
-    queryString =
-      compareToCountry && compareToCountry.length > 0
-        ? `${queryString},${compareToCountry.trim().toLowerCase()}`
-        : queryString;
+    if (compareToCountry != "") {
+        queryParams.compareTo = this.state.compareToCountry
+    }
 
-    // Set the data mode (i.e., total vs. percapita)
-    queryString = `${queryString}?mode=${chartMode}`;
+    superagent
+        .get(queryString)
+        .query(queryParams)
+        .then(res => {
+            this.setState({
+                timeseries: res.body
+            });
 
-    superagent.get(queryString).then(res => {
-      this.setState({
-        timeseries: res.body
-      });
-
-      this.renderChart();
-    });
+            this.renderChart();
+        });
   }
 
   getCountryList() {

--- a/src/js/components/ChartToggles.jsx
+++ b/src/js/components/ChartToggles.jsx
@@ -1,29 +1,44 @@
-import React from 'react';
+import React from "react";
 
-export default class ChartToggles extends React.Component {   
+export default class ChartToggles extends React.Component {
+    constructor(props) {
+        super(props);
+    }
+
     render() {
         return (
-            <div className="btn-group btn-group-toggle" data-toggle="buttons">
-                <label className="btn btn-secondary active">
-                    <input 
-                        type="radio" 
-                        name="total" 
-                        id="total" 
+            <div
+                className="btn-group btn-group-toggle"
+                data-toggle="buttons"
+                title={
+                    this.props.disabled
+                        ? "We are working on getting per capita working for all countries. Please check back later"
+                        : ""
+                }
+            >
+                <label className={`btn btn-secondary active ${ this.props.disabled ? "disabled" : "" }`} >
+                    <input
+                        type="radio"
+                        name="total"
+                        id="total"
                         value="total"
-                        checked={true}
-                        onClick={this.props.onChartModeChange}>
-                    </input> Totals
+                        onClick={this.props.onChartModeChange}
+                        disabled={this.props.disabled}
+                    ></input>{" "}
+                    Totals
                 </label>
-                <label className="btn btn-secondary">
-                    <input 
-                        type="radio" 
-                        name="percapita" 
-                        id="percapita" 
+                <label className={`btn btn-secondary ${ this.props.disabled ? "disabled" : "" }`} >
+                    <input
+                        type="radio"
+                        name="percapita"
+                        id="percapita"
                         value="percapita"
-                        onClick={this.props.onChartModeChange}>
-                    </input> Per 100,000
+                        onClick={this.props.onChartModeChange}
+                        disabled={this.props.disabled}
+                    ></input>{" "}
+                    Per 100,000
                 </label>
-            </div>            
-        )
+            </div>
+        );
     }
 }


### PR DESCRIPTION
Easier than I thought it would be! 

The gist of it is that if more than one country is found in the data, `johnsHopkinsDataMapper()` will split the data on a per-country basis, sum the "columns", and re-combine the two now-summed arrays.

Works pretty well and I've tested with a few edge cases (e.g., countries with many provinces/states, countries with weird names, etc).

Since we don't have population data for all countries (yet), I disable the mode-select button and add a tooltip explaining why it's disabled. 

I'm welcome to feedback!